### PR TITLE
Added IBAN to payment dump

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -306,6 +306,8 @@ var Payment = function(session, json) {
   //
   // - **bank_code** (`String`) -  Bank code of creditor or debtor
   //
+  // - **iban** (`String`) - IBAN of creditor or debtor. Will overwrite bank_code and account_number if both are set
+  //
   // - **bank_name** (`String`) -  Bank name of creditor or debtor
   //
   // - **bank_icon** (`String`) -  Icon of creditor or debtor bank
@@ -328,7 +330,7 @@ var Payment = function(session, json) {
 }
 Payment.prototype = new Base();
 Payment.prototype.constructor = Payment;
-Payment.prototype.dump_attributes = ["type", "name", "account_number", "bank_code", "amount", "currency", "purpose"];
+Payment.prototype.dump_attributes = ["type", "name", "account_number", "bank_code", "iban", "amount", "currency", "purpose"];
 
 // ### Object representing an user
 var User = function(session, json) {


### PR DESCRIPTION
The IBAN Number in the Payment object was missing. This causes the error:

```
"Please provide an IBAN or bank code and account number"
```

Reproduce with:

```JavaScript
payment = new figo.Payment(session, {
  type: "SEPA transfer", 
  name: "figo",
  amount: 14.9,
  currency: "EUR",
  purpose: "Thanks",
  iban: "DE56 6001 0070 0012 3456 78"
})

if (payment.dump().iban !== "DE56 6001 0070 0012 3456 78") {
 throw new Error("IBAN MISSING");
}
```

