### PR TITLE
Do not delete properties from option maps.

### DIFF
--- a/lib/figo.js
+++ b/lib/figo.js
@@ -24,6 +24,7 @@ var https       = require("https");
 var tls         = require("tls");
 var querystring = require("querystring");
 var models      = require("./models");
+var clone       = require("clone");
 
 
 // ### Global configuration.
@@ -717,7 +718,7 @@ var Session = function(access_token) {
   //       The result parameter is an array of `Security` objects.
   //
   this.get_securities = function(options, callback) {
-    options = options == null ? {} : options;
+    options = options == null ? {} : clone(options);
     if (typeof options.since !== "undefined")
       options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;
@@ -779,7 +780,7 @@ var Session = function(access_token) {
   //       The result parameter is an array of `Transaction` objects, one for each transaction of the user.
   //
   this.get_transactions = function(options, callback) {
-    options = options == null ? {} : options;
+    options = options == null ? {} : clone(options);
     if (typeof options.since !== "undefined")
       options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "engines": {
     "node": ">=0.8.0"
+  },
+  "dependencies": {
+    "clone": "^1.0.2"
   }
 }


### PR DESCRIPTION
I got a problem while using your module.

When asking for a list of transactions, this can fail because of an access token, which means it is often needed to retry. When I do this retry, I reuse the same options map I pass to the `get_transactions` function, but because the `account_id` property is removed from this object, the second time I try the filtering by account is not done.

This clones the options map, so that the `account_id` is deleted from a copy and not from the original object.