### PR TITLE
Test on modern set of node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 before_install:
   npm -g install npm@latest
 node_js:
-  - 0.11
-  - 0.10
-  - 0.8
+  - "5"
+  - "4.3"
+  - "0.12"
+  - "0.10"


### PR DESCRIPTION
according to [documentation](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Choosing-Node-versions-to-test-against) node versions should be in quotes. This should fix build. Also, it's time to run tests on modern versions of node. 0.8 is not maintained anymore by node.js org