### PR TITLE
Feature/sdk 15

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,10 +6,11 @@
 //
 // - **error_description** (`String`) - the error description
 //
-var FigoError = function(error, error_description) {
+var FigoError = function(error, error_description, errno) {
   this.name = 'FigoError';
   this.error = error;
   this.error_description = error_description;
+  this.errno = errno;
   this.stack = (new Error()).stack;
 };
 FigoError.prototype = Object.create(Error.prototype);

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -200,8 +200,6 @@ var ALLOWED_NUMBER_OF_ATTEMPTS = 3;
 
 // ### Initialization of https request with a retry count of three.
 //
-// Constructor parameters:
-//
 // - **agent** (`HttpsAgent`) - `HttpsAgent` object
 //
 // - **authorization** (`String`) - encoded authorization in https header

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -192,7 +192,58 @@ var HttpsAgent = function() {
   };
 
   return agent;
-}
+};
+
+
+// constant for number of attempts allowed to make to API, 1 initial and 2 retries, 3 total
+var ALLOWED_NUMBER_OF_ATTEMPTS = 3;
+
+// ### Initialization of https request with a retry count of three.
+//
+// Constructor parameters:
+//
+// - **agent** (`HttpsAgent`) - `HttpsAgent` object
+//
+// - **authorization** (`String`) - encoded authorization in https header
+//
+// - **contentType** (`String`) - content-type for https header
+//
+// - **path** (`String`) - the URL path on the server
+//
+// - **data** (`Object`) - If this parameter is defined, then it will be used as JSON-encoded POST content.
+//
+// - **method** (`Object`) - HTTP method (GET/POST/PUT/DELETE/etc.).
+//
+// - **stringify** (`Object`) - stringify function (either querystring.stringify or JSON.stringify).
+//
+// - **callback** (`Function`) - callback function with two parameters: `error` and `result`
+//
+var queryWithRetries = function (agent, authorization, contentType, contentLength, path, data, method, stringify, callback) {
+  var numberOfAttempts = 0;
+  var query = function () {
+    numberOfAttempts++;
+    agent.figo_request = new HttpsRequest(agent, path, method, function(error, result) {
+      agent.figo_request = null;
+      if (error && numberOfAttempts < ALLOWED_NUMBER_OF_ATTEMPTS && RETRIABLE_ERRORS.indexOf(error.errno) > -1)
+        return query();
+      else
+        return callback(error, result);
+    });
+
+    if (data)
+      data = stringify(data);
+
+    agent.figo_request.setHeader("Authorization", authorization);
+    agent.figo_request.setHeader("Content-Type", contentType);
+    agent.figo_request.setHeader("Content-Length", contentLength(data));
+
+    if (data)
+      agent.figo_request.write(data);
+
+    agent.figo_request.end();
+  };
+  return query();
+};
 
 
 // ### Represents a non user-bound connection to the figo Connect API.
@@ -223,30 +274,19 @@ var Connection = function(client_id, client_secret, redirect_uri) {
   // - **callback** (`Function`) - callback function with two parameters: `error` and `result`
   //
   this.query_api = function(path, data, callback) {
-    var numberOfAttempts = 0;
-    var query = function () {
-      numberOfAttempts++;
-      agent.figo_request = new HttpsRequest(agent, path, "POST", function(error, result) {
-        agent.figo_request = null;
-        if (error && numberOfAttempts < 3 && RETRIABLE_ERRORS.indexOf(error.errno) > -1)
-          return query();
-        else
-          return callback(error, result);
-      });
-
-      if (data)
-        data = querystring.stringify(data);
-
-      agent.figo_request.setHeader("Authorization", "Basic " + new Buffer(client_id + ":" + client_secret).toString("base64"));
-      agent.figo_request.setHeader("Content-Type", "application/x-www-form-urlencoded");
-      agent.figo_request.setHeader("Content-Length", (data ? data.length.toString() : "0"));
-
-      if (data)
-        agent.figo_request.write(data);
-
-      agent.figo_request.end();
-    };
-    return query();
+    return queryWithRetries(
+      agent,
+      "Basic " + new Buffer(client_id + ":" + client_secret).toString("base64"),
+      "application/x-www-form-urlencoded",
+      function (data) {
+        return (data ? data.length.toString() : "0");
+      },
+      path,
+      data,
+      "POST",
+      querystring.stringify,
+      callback
+    );
   };
 
   // **login_url** - Get the URL a user should open in the web browser to start the login process.
@@ -429,30 +469,19 @@ var Session = function(access_token) {
   // - **callback** (`Function`) - callback function with two parameters: `error` and `result`
   //
   this.query_api = function(path, data, method, callback) {
-    var numberOfAttempts = 0;
-    var query = function () {
-      numberOfAttempts++;
-      agent.figo_request = new HttpsRequest(agent, path, method, function(error, result) {
-        agent.figo_request = null;
-        if (error && numberOfAttempts < 3 && RETRIABLE_ERRORS.indexOf(error.errno) > -1)
-          return query();
-        else
-          return callback(error, result);
-      });
-
-      if (data)
-        data = JSON.stringify(data);
-
-      agent.figo_request.setHeader("Authorization", "Bearer " + access_token);
-      agent.figo_request.setHeader("Content-Type", "application/json");
-      agent.figo_request.setHeader("Content-Length", (data ? Buffer.byteLength(data) : "0"));
-
-      if (data)
-        agent.figo_request.write(data);
-
-      agent.figo_request.end();
-    };
-    return query();
+    return queryWithRetries(
+      agent,
+      "Bearer " + access_token,
+      "application/json",
+      function (data) {
+        return (data ? Buffer.byteLength(data) : "0");
+      },
+      path,
+      data,
+      method,
+      JSON.stringify,
+      callback
+    );
   };
 
   this.query_api_object = function(session, entity_type, path, data, method, collection_name, callback) {

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -40,6 +40,17 @@ var Config = {
                         "DB:E2:E9:15:8F:C9:90:30:84:FE:36:CA:A6:11:38:D8:5A:20:5D:93" ],
 };
 
+var RETRIABLE_ERRORS = [
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ESOCKETTIMEDOUT',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+];
+
 
 // ### HTTPS request object with certificate authentication and enhanced error handling.
 //
@@ -149,7 +160,7 @@ var HttpsRequest = function(agent, path, method, callback) {
       if (request.figo_ssl_error) {
         callback(new FigoError("ssl_error", "SSL/TLS certificate fingerprint mismatch."));
       } else {
-        callback(new FigoError("socket_error", error.message));
+        callback(new FigoError("socket_error", error.message, error.errno));
       }
       request.abort();
     }
@@ -212,23 +223,30 @@ var Connection = function(client_id, client_secret, redirect_uri) {
   // - **callback** (`Function`) - callback function with two parameters: `error` and `result`
   //
   this.query_api = function(path, data, callback) {
-    agent.figo_request = new HttpsRequest(agent, path, "POST", function(error, result) {
-      agent.figo_request = null;
-      callback(error, result);
-    });
+    var numberOfAttempts = 0;
+    var query = function () {
+      numberOfAttempts++;
+      agent.figo_request = new HttpsRequest(agent, path, "POST", function(error, result) {
+        agent.figo_request = null;
+        if (error && numberOfAttempts < 3 && RETRIABLE_ERRORS.indexOf(error.errno) > -1)
+          return query();
+        else
+          return callback(error, result);
+      });
 
-    if (data) {
-      data = querystring.stringify(data);
-    }
+      if (data)
+        data = querystring.stringify(data);
 
-    agent.figo_request.setHeader("Authorization", "Basic " + new Buffer(client_id + ":" + client_secret).toString("base64"));
-    agent.figo_request.setHeader("Content-Type", "application/x-www-form-urlencoded");
-    agent.figo_request.setHeader("Content-Length", (data ? data.length.toString() : "0"));
+      agent.figo_request.setHeader("Authorization", "Basic " + new Buffer(client_id + ":" + client_secret).toString("base64"));
+      agent.figo_request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+      agent.figo_request.setHeader("Content-Length", (data ? data.length.toString() : "0"));
 
-    if (data) {
-      agent.figo_request.write(data);
-    }
-    agent.figo_request.end();
+      if (data)
+        agent.figo_request.write(data);
+
+      agent.figo_request.end();
+    };
+    return query();
   };
 
   // **login_url** - Get the URL a user should open in the web browser to start the login process.
@@ -411,23 +429,30 @@ var Session = function(access_token) {
   // - **callback** (`Function`) - callback function with two parameters: `error` and `result`
   //
   this.query_api = function(path, data, method, callback) {
-    var request = new HttpsRequest(agent, path, method, function(error, result) {
-      agent.figo_request = null;
-      callback(error, result);
-    });
-    agent.figo_request = request;
+    var numberOfAttempts = 0;
+    var query = function () {
+      numberOfAttempts++;
+      agent.figo_request = new HttpsRequest(agent, path, method, function(error, result) {
+        agent.figo_request = null;
+        if (error && numberOfAttempts < 3 && RETRIABLE_ERRORS.indexOf(error.errno) > -1)
+          return query();
+        else
+          return callback(error, result);
+      });
 
-    if (data) {
-      data = JSON.stringify(data);
-    }
-    request.setHeader("Authorization", "Bearer " + access_token);
-    request.setHeader("Content-Type", "application/json");
-    request.setHeader("Content-Length", (data ? Buffer.byteLength(data) : "0"));
+      if (data)
+        data = querystring.stringify(data);
 
-    if (data) {
-      request.write(data);
-    }
-    request.end();
+      agent.figo_request.setHeader("Authorization", "Bearer " + access_token);
+      agent.figo_request.setHeader("Content-Type", "application/json");
+      agent.figo_request.setHeader("Content-Length", (data ? Buffer.byteLength(data) : "0"));
+
+      if (data)
+        agent.figo_request.write(data);
+
+      agent.figo_request.end();
+    };
+    return query();
   };
 
   this.query_api_object = function(session, entity_type, path, data, method, collection_name, callback) {

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -218,7 +218,7 @@ var ALLOWED_NUMBER_OF_ATTEMPTS = 3;
 //
 // - **callback** (`Function`) - callback function with two parameters: `error` and `result`
 //
-var queryWithRetries = function (agent, authorization, contentType, contentLength, path, data, method, stringify, callback) {
+var queryWithRetries = function (agent, authorization, contentType, path, data, method, stringify, callback) {
   var numberOfAttempts = 0;
   var query = function () {
     numberOfAttempts++;
@@ -235,7 +235,7 @@ var queryWithRetries = function (agent, authorization, contentType, contentLengt
 
     agent.figo_request.setHeader("Authorization", authorization);
     agent.figo_request.setHeader("Content-Type", contentType);
-    agent.figo_request.setHeader("Content-Length", contentLength(data));
+    agent.figo_request.setHeader("Content-Length", (data ? Buffer.byteLength(data) : 0));
 
     if (data)
       agent.figo_request.write(data);
@@ -278,9 +278,6 @@ var Connection = function(client_id, client_secret, redirect_uri) {
       agent,
       "Basic " + new Buffer(client_id + ":" + client_secret).toString("base64"),
       "application/x-www-form-urlencoded",
-      function (data) {
-        return (data ? data.length.toString() : "0");
-      },
       path,
       data,
       "POST",
@@ -473,9 +470,6 @@ var Session = function(access_token) {
       agent,
       "Bearer " + access_token,
       "application/json",
-      function (data) {
-        return (data ? Buffer.byteLength(data) : "0");
-      },
       path,
       data,
       method,

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -441,7 +441,7 @@ var Session = function(access_token) {
       });
 
       if (data)
-        data = querystring.stringify(data);
+        data = JSON.stringify(data);
 
       agent.figo_request.setHeader("Authorization", "Bearer " + access_token);
       agent.figo_request.setHeader("Content-Type", "application/json");

--- a/test/figo.js
+++ b/test/figo.js
@@ -37,6 +37,7 @@ process.on('uncaughtException', function(err) {
 });
 
 describe("The figo session", function() {
+
   it("should list all accounts", function(done) {
     new figo.Session(access_token).get_accounts(function(error, accounts) {
       expect(error).to.be.null;


### PR DESCRIPTION
New feature to add automatic retries to any API calls that end with the following errno's:

```js
var RETRIABLE_ERRORS = [
    'ECONNRESET',
    'ENOTFOUND',
    'ESOCKETTIMEDOUT',
    'ETIMEDOUT',
    'ECONNREFUSED',
    'EHOSTUNREACH',
    'EPIPE',
    'EAI_AGAIN'
];
```

Issue originated from https://github.com/figo-connect/node-figo/issues/12