### PR TITLE
Feature/sdk 7

### DIFF
--- a/lib/figo.js
+++ b/lib/figo.js
@@ -38,6 +38,22 @@ var Config = {
   // figo Connect TLS certificate fingerprints.
   valid_fingerprints: [ "38:AE:4A:32:6F:16:EA:15:81:33:8B:B0:D8:E4:A6:35:E7:27:F1:07",
                         "DB:E2:E9:15:8F:C9:90:30:84:FE:36:CA:A6:11:38:D8:5A:20:5D:93" ],
+
+  // User-Agent
+  useragent: "node-figo",
+};
+
+
+var setOptions = function (opts) {
+  if (opts.host) {
+    Config.api_endpoint = opts.host;
+  }
+  if (opts.fingerprints) {
+    Config.valid_fingerprints = opts.fingerprints;
+  }
+  if (opts.useragent) {
+    Config.useragent = opts.useragent;
+  }
 };
 
 
@@ -129,7 +145,7 @@ var HttpsRequest = function(agent, path, method, callback) {
 
   // Setup common HTTP headers.
   request.setHeader("Accept", "application/json");
-  request.setHeader("User-Agent", "node-figo");
+  request.setHeader("User-Agent", Config.useragent);
 
   // Setup timeout.
   request.setTimeout(60 * 1000);
@@ -1097,6 +1113,7 @@ module.exports = {
   ProcessToken:          models.ProcessToken,
   Process:               models.Process,
   Config:                Config,
+  setOptions:            setOptions,
   Connection:            Connection,
   Session:               Session
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/figo-connect/node-figo.git"
   },
   "devDependencies": {
+    "async": "~2.0.1",
     "chai": "",
     "mocha": ""
   },

--- a/test/figo.js
+++ b/test/figo.js
@@ -42,9 +42,9 @@ process.on('uncaughtException', function(err) {
 
 // endpont configuration via command line arguments or environment variables
 if ((args = helpers.endpointWasSet())) {
-    access_token = args.access_token;
-    figo.Config.api_endpoint = args.host;
-    figo.Config.valid_fingerprints = args.fingerprints.split(',');
+  access_token = args.access_token;
+  figo.Config.api_endpoint = args.host;
+  figo.Config.valid_fingerprints = args.fingerprints.split(',');
 }
 
 describe("The figo session", function() {

--- a/test/figo.js
+++ b/test/figo.js
@@ -38,9 +38,11 @@ process.on('uncaughtException', function(err) {
 
 // endpont configuration via command line arguments or environment variables
 if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
-    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS)) {
+    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS) &&
+    (process.env.npm_config_access_token || process.env.ACCESS_TOKEN)) {
     var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
     var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
+    access_token = process.env.npm_config_access_token || process.env.ACCESS_TOKEN;
 
     figo.Config.api_endpoint = hostname;
     figo.Config.valid_fingerprints = fingerprints.split(',');

--- a/test/figo.js
+++ b/test/figo.js
@@ -41,7 +41,8 @@ process.on('uncaughtException', function(err) {
 });
 
 // endpont configuration via command line arguments or environment variables
-if (args = helpers.getEndpointFromProcessArgs()) {
+args = helpers.getEndpointFromProcessArgs();
+if (args) {
   access_token = args.access_token;
   figo.setOptions({
     host: args.host,

--- a/test/figo.js
+++ b/test/figo.js
@@ -26,10 +26,14 @@ var expect  = require("chai").expect;
 var figo      = require("../lib/figo");
 var FigoError = require("../lib/errors").FigoError;
 
+// helper functions
+var helpers = require("./helpers");
+
 // Demo client
 var client_id = "CaESKmC8MAhNpDe5rvmWnSkRE_7pkkVIIgMwclgzGcQY";
 var client_secret = "STdzfv0GXtEj_bwYn7AgCVszN1kKq5BdgEIKOM_fzybQ";
 var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRIP_cjLiRiSyQXyt2kM1eXU2XLFZQ0Hro15HikJQT_eNeT_9XQ";
+var args;
 
 // enabling stack traces
 process.on('uncaughtException', function(err) {
@@ -37,15 +41,10 @@ process.on('uncaughtException', function(err) {
 });
 
 // endpont configuration via command line arguments or environment variables
-if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
-    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS) &&
-    (process.env.npm_config_access_token || process.env.ACCESS_TOKEN)) {
-    var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
-    var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
-    access_token = process.env.npm_config_access_token || process.env.ACCESS_TOKEN;
-
-    figo.Config.api_endpoint = hostname;
-    figo.Config.valid_fingerprints = fingerprints.split(',');
+if ((args = helpers.endpointWasSet())) {
+    access_token = args.access_token;
+    figo.Config.api_endpoint = args.host;
+    figo.Config.valid_fingerprints = args.fingerprints.split(',');
 }
 
 describe("The figo session", function() {

--- a/test/figo.js
+++ b/test/figo.js
@@ -41,7 +41,7 @@ process.on('uncaughtException', function(err) {
 });
 
 // endpont configuration via command line arguments or environment variables
-if ((args = helpers.endpointWasSet())) {
+if ((args = helpers.getEndpointFromProcessArgs())) {
   access_token = args.access_token;
   figo.Config.api_endpoint = args.host;
   figo.Config.valid_fingerprints = args.fingerprints.split(',');

--- a/test/figo.js
+++ b/test/figo.js
@@ -36,6 +36,16 @@ process.on('uncaughtException', function(err) {
   console.error('Caught exception: ' + err.stack);
 });
 
+// endpont configuration via command line arguments or environment variables
+if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
+    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS)) {
+    var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
+    var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
+
+    figo.Config.api_endpoint = hostname;
+    figo.Config.valid_fingerprints = fingerprints.split(',');
+}
+
 describe("The figo session", function() {
   it("should list all accounts", function(done) {
     new figo.Session(access_token).get_accounts(function(error, accounts) {

--- a/test/figo.js
+++ b/test/figo.js
@@ -43,8 +43,10 @@ process.on('uncaughtException', function(err) {
 // endpont configuration via command line arguments or environment variables
 if ((args = helpers.getEndpointFromProcessArgs())) {
   access_token = args.access_token;
-  figo.Config.api_endpoint = args.host;
-  figo.Config.valid_fingerprints = args.fingerprints.split(',');
+  figo.setOptions({
+    host: args.host,
+    fingerprints: args.fingerprints.split(','),
+  });
 }
 
 describe("The figo session", function() {

--- a/test/figo.js
+++ b/test/figo.js
@@ -41,7 +41,7 @@ process.on('uncaughtException', function(err) {
 });
 
 // endpont configuration via command line arguments or environment variables
-if ((args = helpers.getEndpointFromProcessArgs())) {
+if (args = helpers.getEndpointFromProcessArgs()) {
   access_token = args.access_token;
   figo.setOptions({
     host: args.host,
@@ -342,4 +342,3 @@ describe("The figo session", function() {
     });
   });
 });
-

--- a/test/figo.js
+++ b/test/figo.js
@@ -120,7 +120,7 @@ describe("The figo session", function() {
     });
   });
 
-  it("should list login settings for a bank or service", function(done) {
+  it("shouldn't list login settings for a bank or service", function(done) {
     new figo.Session(access_token).get_login_settings("de", "90090042", function(error, login_settings) {
         expect(error).to.be.instanceof(Object);
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,27 @@
+// retrieve string that matches regex
+var _contains = function (arr, str) {
+  for (var i = 0, len = arr.length; i < len; i++) {
+    if (arr[i].match(RegExp(str))) {
+      return arr[i].substr(arr[i].indexOf("=") + 1);
+    }
+  }
+  return false;
+};
+
+var endpointWasSet = function () {
+  var host         = process.env.HOST         || _contains(process.argv, "--host=");
+  var fingerprints = process.env.FINGERPRINTS || _contains(process.argv, "--fingerprints=");
+  var access_token = process.env.ACCESS_TOKEN || _contains(process.argv, "--access_token=");
+  if (host && fingerprints && access_token) {
+    return {
+      host: host,
+      fingerprints: fingerprints,
+      access_token: access_token,
+    };
+  }
+  return false;
+};
+
+module.exports = {
+  endpointWasSet: endpointWasSet,
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,17 +1,18 @@
 // retrieve string that matches regex
-var _contains = function (arr, str) {
+var _getFromProcessArgs = function (str) {
+  var arr = process.argv;
   for (var i = 0, len = arr.length; i < len; i++) {
     if (arr[i].match(RegExp(str))) {
       return arr[i].substr(arr[i].indexOf("=") + 1);
     }
   }
-  return false;
+  return null;
 };
 
 var endpointWasSet = function () {
-  var host         = process.env.HOST         || _contains(process.argv, "--host=");
-  var fingerprints = process.env.FINGERPRINTS || _contains(process.argv, "--fingerprints=");
-  var access_token = process.env.ACCESS_TOKEN || _contains(process.argv, "--access_token=");
+  var host         = process.env.HOST         || _getFromProcessArgs("--host=");
+  var fingerprints = process.env.FINGERPRINTS || _getFromProcessArgs("--fingerprints=");
+  var access_token = process.env.ACCESS_TOKEN || _getFromProcessArgs("--access_token=");
   if (host && fingerprints && access_token) {
     return {
       host: host,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@ var _getFromProcessArgs = function (str) {
   return null;
 };
 
-var endpointWasSet = function () {
+var getEndpointFromProcessArgs = function () {
   var host         = process.env.HOST         || _getFromProcessArgs("--host=");
   var fingerprints = process.env.FINGERPRINTS || _getFromProcessArgs("--fingerprints=");
   var access_token = process.env.ACCESS_TOKEN || _getFromProcessArgs("--access_token=");
@@ -20,9 +20,9 @@ var endpointWasSet = function () {
       access_token: access_token,
     };
   }
-  return false;
+  return null;
 };
 
 module.exports = {
-  endpointWasSet: endpointWasSet,
+  getEndpointFromProcessArgs: getEndpointFromProcessArgs,
 };

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -37,8 +37,10 @@ var args;
 // endpont configuration via command line arguments or environment variables
 if ((args = helpers.getEndpointFromProcessArgs())) {
   access_token = args.access_token;
-  figo.Config.api_endpoint = args.host;
-  figo.Config.valid_fingerprints = args.fingerprints.split(',');
+  figo.setOptions({
+    host: args.host,
+    fingerprints: args.fingerprints.split(','),
+  });
 }
 
 describe('Parallel query tests', function () {

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -36,9 +36,9 @@ var args;
 
 // endpont configuration via command line arguments or environment variables
 if ((args = helpers.endpointWasSet())) {
-    access_token = args.access_token;
-    figo.Config.api_endpoint = args.host;
-    figo.Config.valid_fingerprints = args.fingerprints.split(',');
+  access_token = args.access_token;
+  figo.Config.api_endpoint = args.host;
+  figo.Config.valid_fingerprints = args.fingerprints.split(',');
 }
 
 describe('Parallel query tests', function () {

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -30,6 +30,16 @@ var client_id = "CaESKmC8MAhNpDe5rvmWnSkRE_7pkkVIIgMwclgzGcQY";
 var client_secret = "STdzfv0GXtEj_bwYn7AgCVszN1kKq5BdgEIKOM_fzybQ";
 var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRIP_cjLiRiSyQXyt2kM1eXU2XLFZQ0Hro15HikJQT_eNeT_9XQ";
 
+// endpont configuration via command line arguments or environment variables
+if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
+    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS)) {
+    var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
+    var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
+
+    figo.Config.api_endpoint = hostname;
+    figo.Config.valid_fingerprints = fingerprints.split(',');
+}
+
 describe('Parallel query tests', function () {
   var accounts,
       sequentialTransactions = [],
@@ -73,6 +83,7 @@ describe('Parallel query tests', function () {
         for (var i=0; i<len; i++)
           parallelTransactions = parallelTransactions.concat(transactions[i]);
 
+        expect(sequentialTransactions.length).to.not.equal(0);
         expect(sequentialTransactions.length).to.equal(parallelTransactions.length);
         done();
       });
@@ -97,6 +108,7 @@ describe('Parallel query tests', function () {
         for (var i=0; i<len; i++)
           parallelTransactions = parallelTransactions.concat(transactions[i]);
 
+        expect(sequentialTransactions.length).to.not.equal(0);
         expect(sequentialTransactions.length).to.equal(parallelTransactions.length);
         done();
       });

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -35,7 +35,8 @@ var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRI
 var args;
 
 // endpont configuration via command line arguments or environment variables
-if ((args = helpers.getEndpointFromProcessArgs())) {
+args = helpers.getEndpointFromProcessArgs();
+if (args) {
   access_token = args.access_token;
   figo.setOptions({
     host: args.host,

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -32,9 +32,11 @@ var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRI
 
 // endpont configuration via command line arguments or environment variables
 if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
-    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS)) {
+    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS) &&
+    (process.env.npm_config_access_token || process.env.ACCESS_TOKEN)) {
     var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
     var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
+    access_token = process.env.npm_config_access_token || process.env.ACCESS_TOKEN;
 
     figo.Config.api_endpoint = hostname;
     figo.Config.valid_fingerprints = fingerprints.split(',');

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -35,7 +35,7 @@ var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRI
 var args;
 
 // endpont configuration via command line arguments or environment variables
-if ((args = helpers.endpointWasSet())) {
+if ((args = helpers.getEndpointFromProcessArgs())) {
   access_token = args.access_token;
   figo.Config.api_endpoint = args.host;
   figo.Config.valid_fingerprints = args.fingerprints.split(',');

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -25,21 +25,20 @@ var async = require("async");
 
 var figo = require("../lib/figo");
 
+// helper functions
+var helpers = require("./helpers");
+
 // Demo client
 var client_id = "CaESKmC8MAhNpDe5rvmWnSkRE_7pkkVIIgMwclgzGcQY";
 var client_secret = "STdzfv0GXtEj_bwYn7AgCVszN1kKq5BdgEIKOM_fzybQ";
 var access_token = "ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo22ujRIP_cjLiRiSyQXyt2kM1eXU2XLFZQ0Hro15HikJQT_eNeT_9XQ";
+var args;
 
 // endpont configuration via command line arguments or environment variables
-if ((process.env.npm_config_hostname || process.env.FIGO_HOST) &&
-    (process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS) &&
-    (process.env.npm_config_access_token || process.env.ACCESS_TOKEN)) {
-    var hostname = process.env.npm_config_hostname || process.env.FIGO_HOST;
-    var fingerprints = process.env.npm_config_fingerprints || process.env.FIGO_FINGERPRINTS;
-    access_token = process.env.npm_config_access_token || process.env.ACCESS_TOKEN;
-
-    figo.Config.api_endpoint = hostname;
-    figo.Config.valid_fingerprints = fingerprints.split(',');
+if ((args = helpers.endpointWasSet())) {
+    access_token = args.access_token;
+    figo.Config.api_endpoint = args.host;
+    figo.Config.valid_fingerprints = args.fingerprints.split(',');
 }
 
 describe('Parallel query tests', function () {


### PR DESCRIPTION
Feature to point `npm test` to different host. Arguments needed:
- `HOST=api.figo.me` or `--host=api.figo.me`
- `FINGERPRINTS=11:22:33:44,AA:BB:CC:DD` or `--fingerprints=11:22:33:44,AA:BB:CC:DD`
- `ACCESS_TOKEN=ASHWLIkouP2O6` or `--access_token=ASHWLIkouP2O6`

``` bash
#example 1
HOST=api.figo.me FINGERPRINTS=11:22:33:44,AA:BB:CC:DD ACCESS_TOKEN=ASHWLIkouP2O6 npm test
#example 2
npm test -- --host=api.figo.me --fingerprints=11:22:33:44,AA:BB:CC:DD --access_token=ASHWLIkouP2O6
```

To set options when `require`ing the SDK, call `setOptions`

``` js
var figo = require("../lib/figo");

figo.setOptions({
    host: 'api.figo.me',
    fingerprints: ['11:22:33:44'],
    useragent: 'figo-connect',
  });
}
```
