### PR TITLE
Use Error.captureStackTrace to create the stack property

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,11 +7,12 @@
 // - **error_description** (`String`) - the error description
 //
 var FigoError = function(error, error_description, errno) {
+  Error.captureStackTrace(this, FigoError);
+
   this.name = 'FigoError';
   this.error = error;
-  this.error_description = error_description;
+  this.message = this.error_description = error_description;
   this.errno = errno;
-  this.stack = (new Error()).stack;
 };
 FigoError.prototype = Object.create(Error.prototype);
 FigoError.prototype.constructor = FigoError;
@@ -20,5 +21,5 @@ FigoError.prototype.toString = function() {
 };
 
 module.exports = {
-    FigoError: FigoError
+  FigoError: FigoError
 };


### PR DESCRIPTION
When subclassing `Error` in Node.js it is a good practice to use [`Error.captureStackTrace`](https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt) to create the stack property. See the following example:

```js
'use strict';

const FigoError = require('./lib/errors').FigoError;

const err = new FigoError('foo', 'bar');

console.log(err.stack);
```

Before this patch:
```
Error
    at new FigoError (/Users/luigi/repos/node-figo/lib/errors.js:14:17)
    at Object.<anonymous> (/Users/luigi/repos/node-figo/throw.js:5:13)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
```

After this patch:
```
FigoError: bar
    at Object.<anonymous> (/Users/luigi/repos/node-figo/throw.js:5:13)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
```