### PR TITLE
Use built-ins when possible

### DIFF
--- a/lib/figo.js
+++ b/lib/figo.js
@@ -27,7 +27,6 @@ var querystring = require("querystring");
 var crypto      = require("crypto");
 
 // External dependencies.
-var clone       = require("clone");
 var winston     = require("winston");
 
 // Internal modules.
@@ -785,7 +784,16 @@ var Session = function(access_token) {
   //       The result parameter is an array of `Security` objects.
   //
   this.get_securities = function(options, callback) {
-    options = options == null ? {} : clone(options);
+    if (typeof options === "object" && options !== null) {
+      try {
+        options = JSON.parse(JSON.stringify(options));
+      } catch (e) {
+        winston.log('warn', 'corrupted `options` object');
+        options = {};
+      }
+    } else {
+      options = {};
+    }
     if (typeof options.since !== "undefined")
       options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;
@@ -847,7 +855,16 @@ var Session = function(access_token) {
   //       The result parameter is an array of `Transaction` objects, one for each transaction of the user.
   //
   this.get_transactions = function(options, callback) {
-    options = options == null ? {} : clone(options);
+    if (typeof options === "object" && options !== null) {
+      try {
+        options = JSON.parse(JSON.stringify(options));
+      } catch (e) {
+        winston.log('warn', 'corrupted `options` object');
+        options = {};
+      }
+    } else {
+      options = {};
+    }
     if (typeof options.since !== "undefined")
       options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;

--- a/lib/figo.js
+++ b/lib/figo.js
@@ -794,8 +794,6 @@ var Session = function(access_token) {
     } else {
       options = {};
     }
-    if (typeof options.since !== "undefined")
-      options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;
     options.offset = typeof options.offset === "undefined" ? 0 : options.offset;
     if (typeof options.account_id === "undefined") {
@@ -865,8 +863,6 @@ var Session = function(access_token) {
     } else {
       options = {};
     }
-    if (typeof options.since !== "undefined")
-      options.since = typeof options.since === "object" ? options.since.toISOString() : options.since;
     options.count = typeof options.count === "undefined" ? 1000 : options.count;
     options.offset = typeof options.offset === "undefined" ? 0 : options.offset;
     options.include_pending = options.include_pending ? 1 : 0;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">=0.11.0"
   },
   "dependencies": {
-    "clone": "^1.0.2",
     "winston": "^2.3.0"
   }
 }


### PR DESCRIPTION
Follow-up on https://github.com/figo-connect/node-figo/pull/8: use standard JSON methods to deep clone `options` object.

This will also eliminate outdated dependency issue:

<img width="958" alt="screen shot 2017-08-13 at 20 55 17" src="https://user-images.githubusercontent.com/199476/29252538-c8779552-8069-11e7-9574-b3b3c720db30.png">