### PR TITLE
only set content-type header if there is content

### DIFF
--- a/lib/figo.js
+++ b/lib/figo.js
@@ -267,10 +267,10 @@ var queryWithRetries = function (agent, authorization, contentType, path, data, 
 
     if (data) {
       data = stringify(clean(data));
+      agent.figo_request.setHeader("Content-Type", contentType);
     }
 
     agent.figo_request.setHeader("Authorization", authorization);
-    agent.figo_request.setHeader("Content-Type", contentType);
     agent.figo_request.setHeader("Content-Length", (data ? Buffer.byteLength(data) : 0));
 
     if (data)


### PR DESCRIPTION
Due to recent fixes in the api this needs to be adjusted.